### PR TITLE
Fix clients not being able to connect to UDP voice servers.

### DIFF
--- a/src/main/java/net/gliby/voicechat/client/networking/ClientNetwork.java
+++ b/src/main/java/net/gliby/voicechat/client/networking/ClientNetwork.java
@@ -64,11 +64,11 @@ public class ClientNetwork {
 
       VoiceChatClient.getSoundManager().reset();
 
-      switch (type.ordinal()) {
-         case 1:
+      switch (type) {
+         case MINECRAFT:
             this.voiceClient = new MinecraftVoiceClient(type);
             break;
-         case 2:
+         case UDP:
             String serverAddress = ip;
             if (ip.isEmpty()) {
                ServerData serverData;

--- a/src/main/java/net/gliby/voicechat/client/render/RenderPlayerVoiceIcon.java
+++ b/src/main/java/net/gliby/voicechat/client/render/RenderPlayerVoiceIcon.java
@@ -94,6 +94,7 @@ public class RenderPlayerVoiceIcon extends Gui {
                     }
                 }
             }
+            GL11.glEnabled(2929);
             GL11.glDisable(3042);
             GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         }

--- a/src/main/java/net/gliby/voicechat/common/networking/voiceservers/udp/UDPVoiceServer.java
+++ b/src/main/java/net/gliby/voicechat/common/networking/voiceservers/udp/UDPVoiceServer.java
@@ -135,6 +135,10 @@ public class UDPVoiceServer extends VoiceAuthenticatedServer
             {
                 UDPVoiceServer.this.handler.read(evt.getPacketAsBytes(), evt.getPacket());
             }
+            catch (EOFException e)
+            {
+                break;
+            }
             catch (Exception e)
             {
                 e.printStackTrace();

--- a/src/main/java/net/gliby/voicechat/common/networking/voiceservers/udp/UDPVoiceServer.java
+++ b/src/main/java/net/gliby/voicechat/common/networking/voiceservers/udp/UDPVoiceServer.java
@@ -137,7 +137,7 @@ public class UDPVoiceServer extends VoiceAuthenticatedServer
             }
             catch (EOFException e)
             {
-                break;
+                
             }
             catch (Exception e)
             {

--- a/src/main/java/net/gliby/voicechat/common/networking/voiceservers/udp/UDPVoiceServer.java
+++ b/src/main/java/net/gliby/voicechat/common/networking/voiceservers/udp/UDPVoiceServer.java
@@ -11,6 +11,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.StringUtils;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.util.HashMap;
@@ -134,10 +135,6 @@ public class UDPVoiceServer extends VoiceAuthenticatedServer
             try
             {
                 UDPVoiceServer.this.handler.read(evt.getPacketAsBytes(), evt.getPacket());
-            }
-            catch (EOFException e)
-            {
-                
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Due to a screwed up switch statement in the ClientNetwork class, clients haven't been able to connect to voice servers using UDP. Simply changing this switch statement to use the enum itself for the switch statement fixes this problem in my testing.

This is a very important fix since using UDP is a lot more performant and reliable than using TCP for voice chat.

I've tested this on a server and it fixes the issue completely, although I have found some UDP related errors showing up in the console which would likely show up when using UDP either way (but the voice chat still works completely fine).

I'd also like to mention this change occurred with your version of the mod, not sure why it happened. The fix I'm applying actually makes things identical to the original mod.

I also fixed an unrelated issue with rendering the voice chat icon where the depth testing was not re-enabled after rendering. It didn't seem to affect anything, but it should help with some rendering bugs if there are any.